### PR TITLE
Certificates need to be in us-east-1

### DIFF
--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -34,10 +34,6 @@ provider "aws" {
   profile = "default"
   region  = "us-west-2"
 }
-provider "aws" {
-  alias           = "us_east_1"
-  region          = "us-east-1"
-}
 
 # Held here so that Helm and K8s providers can be initialized to work on this cluster
 resource "digitalocean_kubernetes_cluster" "foreign_language_reader" {

--- a/infrastructure.tf
+++ b/infrastructure.tf
@@ -34,6 +34,10 @@ provider "aws" {
   profile = "default"
   region  = "us-west-2"
 }
+provider "aws" {
+  alias           = "us_east_1"
+  region          = "us-east-1"
+}
 
 # Held here so that Helm and K8s providers can be initialized to work on this cluster
 resource "digitalocean_kubernetes_cluster" "foreign_language_reader" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,19 +79,19 @@ module "frontend_preprod" {
   deploy_users = [aws_iam_user.github.name]
 }
 
-module "frontend_fluent_labs" {
-  source       = "./static_bucket"
-  domain       = digitalocean_domain.fluentlabs.name
-  subdomain    = "www"
-  deploy_users = [aws_iam_user.github.name]
-}
+# module "frontend_fluent_labs" {
+#   source       = "./static_bucket"
+#   domain       = digitalocean_domain.fluentlabs.name
+#   subdomain    = "www"
+#   deploy_users = [aws_iam_user.github.name]
+# }
 
-module "frontend_preprod_fluent_labs" {
-  source       = "./static_bucket"
-  domain       = digitalocean_domain.fluentlabs.name
-  subdomain    = "preprod"
-  deploy_users = [aws_iam_user.github.name]
-}
+# module "frontend_preprod_fluent_labs" {
+#   source       = "./static_bucket"
+#   domain       = digitalocean_domain.fluentlabs.name
+#   subdomain    = "preprod"
+#   deploy_users = [aws_iam_user.github.name]
+# }
 
 module "api" {
   source        = "./api"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -202,6 +202,7 @@ resource "acme_certificate" "certificate_fluent_labs" {
 }
 
 resource "aws_acm_certificate" "cert" {
+  provider = aws.us_east_1
   private_key       = acme_certificate.certificate_fluent_labs.private_key_pem
   certificate_body  = acme_certificate.certificate_fluent_labs.certificate_pem
   certificate_chain = acme_certificate.certificate_fluent_labs.issuer_pem

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,8 +17,8 @@ terraform {
 
 # Certificate manager certificates need to be in us-east-1
 provider "aws" {
-  alias           = "us_east_1"
-  region          = "us-east-1"
+  alias  = "us_east_1"
+  region = "us-east-1"
 }
 
 # Hold K8s configuration in an intermediate level
@@ -208,7 +208,7 @@ resource "acme_certificate" "certificate_fluent_labs" {
 }
 
 resource "aws_acm_certificate" "cert" {
-  provider = aws.us_east_1
+  provider          = aws.us_east_1
   private_key       = acme_certificate.certificate_fluent_labs.private_key_pem
   certificate_body  = acme_certificate.certificate_fluent_labs.certificate_pem
   certificate_chain = acme_certificate.certificate_fluent_labs.issuer_pem

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,6 +15,12 @@ terraform {
   }
 }
 
+# Certificate manager certificates need to be in us-east-1
+provider "aws" {
+  alias           = "us_east_1"
+  region          = "us-east-1"
+}
+
 # Hold K8s configuration in an intermediate level
 # Terraform currently cannot create a cluster and use it to set up a provider on the same leve.
 

--- a/terraform/static_bucket/main.tf
+++ b/terraform/static_bucket/main.tf
@@ -18,7 +18,8 @@ data "digitalocean_domain" "main" {
 data "aws_caller_identity" "current" {}
 
 data "aws_acm_certificate" "cert" {
-  domain = "*.${var.domain}"
+  provider = aws.us_east_1
+  domain   = "*.${var.domain}"
 }
 
 resource "aws_s3_bucket" "main" {

--- a/terraform/static_bucket/main.tf
+++ b/terraform/static_bucket/main.tf
@@ -9,8 +9,8 @@ terraform {
 
 # Certificate manager certificates need to be in us-east-1
 provider "aws" {
-  alias           = "us_east_1"
-  region          = "us-east-1"
+  alias  = "us_east_1"
+  region = "us-east-1"
 }
 
 locals {

--- a/terraform/static_bucket/main.tf
+++ b/terraform/static_bucket/main.tf
@@ -7,6 +7,12 @@ terraform {
   }
 }
 
+# Certificate manager certificates need to be in us-east-1
+provider "aws" {
+  alias           = "us_east_1"
+  region          = "us-east-1"
+}
+
 locals {
   full_domain = "${var.subdomain}.${var.domain}"
 }


### PR DESCRIPTION
Cloudfront requires these certificates to be in us-east-1. Ok fine, put them there.