### PR TITLE
Switch backend to fluentlabs.io

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -121,7 +121,7 @@ module "content" {
 
 module "elasticsearch" {
   source           = "./elasticsearch"
-  domain           = digitalocean_domain.main.name
+  domain           = digitalocean_domain.fluentlabs.name
   api_password     = module.api.elasticsearch_password
   fluentd_password = module.monitoring.fluentd_password
   spark_password   = module.content.elasticsearch_password
@@ -138,11 +138,11 @@ module "monitoring" {
 
 module "nginx_ingress" {
   source          = "./nginx_ingress"
-  domain          = digitalocean_domain.main.name
+  domain          = digitalocean_domain.fluentlabs.name
   subdomains      = ["api"]
-  private_key_pem = acme_certificate.certificate.private_key_pem
-  certificate_pem = acme_certificate.certificate.certificate_pem
-  issuer_pem      = acme_certificate.certificate.issuer_pem
+  private_key_pem = acme_certificate.certificate_fluent_labs.private_key_pem
+  certificate_pem = acme_certificate.certificate_fluent_labs.certificate_pem
+  issuer_pem      = acme_certificate.certificate_fluent_labs.issuer_pem
   namespace       = "default"
 }
 

--- a/terraform/nginx_ingress/main.tf
+++ b/terraform/nginx_ingress/main.tf
@@ -60,7 +60,7 @@ resource "digitalocean_record" "kubernetes_subdomain_dns" {
 
 resource "kubernetes_ingress" "ingress" {
   metadata {
-    name = "foreign-language-reader-ingress"
+    name = "fluentlabs-ingress"
     annotations = {
       "kubernetes.io/ingress.class"             = "nginx"
       "nginx.ingress.kubernetes.io/enable-cors" = "true"
@@ -69,12 +69,12 @@ resource "kubernetes_ingress" "ingress" {
 
   spec {
     tls {
-      hosts       = ["api.foreignlanguagereader.com"]
+      hosts       = ["api.fluentlabs.io"]
       secret_name = "nginx-certificate"
     }
 
     rule {
-      host = "api.foreignlanguagereader.com"
+      host = "api.fluentlabs.io"
       http {
         path {
           backend {


### PR DESCRIPTION
Serve traffic on a new domain name.