### PR TITLE
Sematext dual publish

### DIFF
--- a/terraform/monitoring/fluentd.yml
+++ b/terraform/monitoring/fluentd.yml
@@ -1,7 +1,8 @@
 elasticsearch:
+  auth:
+    enabled: true
+    user: fluentd
   hosts: 
-    - logsene-receiver.sematext.com
-  logstash:
-    enabled: false
+    - elastic-es-http.default.svc.cluster.local
   scheme: https
-  sslVerify: true
+  sslVerify: false

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -37,6 +37,23 @@ resource "helm_release" "prometheus_operator" {
   version    = "3.3.2"
 }
 
+resource "helm_release" "sematext_logagent" {
+  name       = "sematext"
+  repository = "https://cdn.sematext.com/helm-charts"
+  chart      = "st-logagent"
+  version    = "1.0.35"
+
+  set {
+    name  = "region"
+    value = "US"
+  }
+
+  set_sensitive {
+    name  = "logsToken"
+    value = var.sematext_index_name.result
+  }
+}
+
 # resource "kubernetes_manifest" "api_prometheus" {
 #   provider = kubernetes-alpha
 #   manifest = yamldecode(file("${path.module}/api_prometheus.yml"))

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -25,8 +25,8 @@ resource "helm_release" "fluentd_elasticsearch" {
   values = [file("${path.module}/fluentd.yml")]
 
   set_sensitive {
-    name  = "elasticsearch.indexName"
-    value = var.sematext_index_name
+    name  = "elasticsearch.auth.password"
+    value = random_password.fluent_elasticsearch_password.result
   }
 }
 

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -50,7 +50,7 @@ resource "helm_release" "sematext_logagent" {
 
   set_sensitive {
     name  = "logsToken"
-    value = var.sematext_index_name.result
+    value = var.sematext_index_name
   }
 }
 


### PR DESCRIPTION
Keep logs going to elasticsearch while we are iterating. This uses the custom log shipper provided by sematext.