### PR TITLE
Directly import certificate to AWS certificate manager

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,17 +64,19 @@ module "database" {
 # Static content served to users
 
 module "frontend_fluent_labs" {
-  source       = "./static_bucket"
-  domain       = aws_route53_zone.main.name
-  subdomain    = "www"
-  deploy_users = [aws_iam_user.github.name]
+  source          = "./static_bucket"
+  domain          = aws_route53_zone.main.name
+  subdomain       = "www"
+  deploy_users    = [aws_iam_user.github.name]
+  certificate_arn = aws_acm_certificate.cert.arn
 }
 
 module "frontend_preprod_fluent_labs" {
-  source       = "./static_bucket"
-  domain       = aws_route53_zone.main.name
-  subdomain    = "preprod"
-  deploy_users = [aws_iam_user.github.name]
+  source          = "./static_bucket"
+  domain          = aws_route53_zone.main.name
+  subdomain       = "preprod"
+  deploy_users    = [aws_iam_user.github.name]
+  certificate_arn = aws_acm_certificate.cert.arn
 }
 
 module "api" {

--- a/terraform/static_bucket/main.tf
+++ b/terraform/static_bucket/main.tf
@@ -7,21 +7,8 @@ terraform {
   }
 }
 
-# Certificate manager certificates need to be in us-east-1
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1"
-}
-
 locals {
   full_domain = "${var.subdomain}.${var.domain}"
-}
-
-data "aws_caller_identity" "current" {}
-
-data "aws_acm_certificate" "cert" {
-  provider = aws.us_east_1
-  domain   = "*.${var.domain}"
 }
 
 resource "aws_s3_bucket" "main" {
@@ -114,7 +101,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   }
 
   viewer_certificate {
-    acm_certificate_arn = data.aws_acm_certificate.cert.arn
+    acm_certificate_arn = var.certificate_arn
     ssl_support_method  = "sni-only"
   }
 }

--- a/terraform/static_bucket/variables.tf
+++ b/terraform/static_bucket/variables.tf
@@ -9,3 +9,7 @@ variable "domain" {
 variable "subdomain" {
   description = "The subdomain the site will be hosted on."
 }
+
+variable "certificate_arn" {
+  description = "The ARN of the certificate in AWS certificate manager"
+}


### PR DESCRIPTION
## Problem
We create an AWS certificate, and then refer to it using a data resource within. the static buckets module. This works if it exists and on first creation. However, if the certificate has expired, the indirect reference breaks planning, and terraform can't create the certificate again.

## Solution
Directly refer the certificate to the static buckets. This explicitly shows Terraform the dependency, so it can create the certificate if it doesn't exist.