### PR TITLE
Don't destroy certificates that don't exist.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -174,4 +174,8 @@ resource "aws_acm_certificate" "cert" {
   private_key       = acme_certificate.certificate_fluent_labs.private_key_pem
   certificate_body  = acme_certificate.certificate_fluent_labs.certificate_pem
   certificate_chain = acme_certificate.certificate_fluent_labs.issuer_pem
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
## Problem:
If a certificate expires, AWS will helpfully delete it. Then when rotating, Terraform also tries to delete it, but it doesn't exist. This blocks creation, and we loop.

## Solution
Desired behavior is to create the new certificate, and then try to delete the old one. If it isn't there, deletion will fail and so will the run. The next plan will notice the new certificate is correctly there, and the old one isn't, so it will leave it alone, breaking the cycle.