### PR TITLE
Fix ingress dns

### DIFF
--- a/terraform/nginx_ingress/main.tf
+++ b/terraform/nginx_ingress/main.tf
@@ -51,9 +51,9 @@ resource "aws_route53_record" "subdomain" {
   for_each = toset(var.subdomains)
   zone_id  = data.aws_route53_zone.main.zone_id
   name     = "${each.value}.fluentlabs.io"
-  type     = "CNAME"
+  type     = "A"
   ttl      = "3600"
-  records  = [data.kubernetes_service.nginx.status.0.load_balancer.0.ingress.0.hostname]
+  records  = [data.kubernetes_service.nginx.status.0.load_balancer.0.ingress.0.ip]
 }
 
 resource "kubernetes_ingress_v1" "ingress" {


### PR DESCRIPTION
AWS uses cname, digitalocean uses IP address